### PR TITLE
Wait for the gyro to be fully calibrated

### DIFF
--- a/src/main/java/org/firstinspires/ftc/teamcode/Mecanum_Wheels_Generic.java
+++ b/src/main/java/org/firstinspires/ftc/teamcode/Mecanum_Wheels_Generic.java
@@ -502,6 +502,11 @@ public class Mecanum_Wheels_Generic extends LinearOpMode {
         // Initialize the gyro.
         info("* Initializing gyro sensor...");
         gyro = hardwareMap.gyroSensor.get("gyro");
+        // It takes several seconds to calibrate, so show a message on the telemetry data.
+        telemetry.addData(">", "Calibrating the gyro sensor...");
+        telemetry.update();
+        gyro.calibrate();
+        while(gyro.isCalibrating() && !isStopRequested());
 
         info("Initialization complete.");
     }


### PR DESCRIPTION
(Note: This does not have to be accepted and merged until after Super Regionals! Just pushing it here as a pull request so it doesn't get lost.)

The gyro.calibrate() call returns before the gyro is actually calibrated. We should wait on isCalibrating() for the calibration to actually finish before completing initialization.